### PR TITLE
WS-47: Fix for any player being able to start game

### DIFF
--- a/.changeset/chatty-cooks-deny.md
+++ b/.changeset/chatty-cooks-deny.md
@@ -1,0 +1,5 @@
+---
+"ws-react-client": patch
+---
+
+fixed issue where any player can start the game

--- a/packages/ws-react-client/src/components/pages/game/Lobby/Lobby.tsx
+++ b/packages/ws-react-client/src/components/pages/game/Lobby/Lobby.tsx
@@ -95,7 +95,7 @@ const Lobby = ({ code, players, startGame, leaveGame }: Props) => {
         </div>
       </CardContainer>
       <ButtonGroup direction="column">
-        <Button variant="primary" disabled={!isHost} onClick={handleStartGame} text="Start Game" />
+        <Button variant="primary" disabled={!isHost()} onClick={handleStartGame} text="Start Game" />
         <Button variant="primary" onClick={handleLeaveGame} text="Leave Lobby" />
       </ButtonGroup>
       <Footer />


### PR DESCRIPTION
Resolves #47 

Fixes an issue where the start button would not be disabled for players who were not the host. 
